### PR TITLE
Unreachable statement

### DIFF
--- a/src/main/java/ru/sbtqa/tag/pagefactory/support/DesiredCapabilitiesParser.java
+++ b/src/main/java/ru/sbtqa/tag/pagefactory/support/DesiredCapabilitiesParser.java
@@ -41,7 +41,7 @@ public class DesiredCapabilitiesParser {
 
             String capability = rawCapabilityKey.substring(capsPrefix.length());
 
-            if (capability.startsWith("options") && "Chrome".equals(TagWebDriver.getBrowserName())) {
+            if (capability.startsWith("options") && "chrome".equals(TagWebDriver.getBrowserName())) {
                 // For Chrome options must be parsed and specified as a data structure.
                 // For non-chrome browsers options could be passed as string
                 String optionsCapability = capability.substring("options.".length());


### PR DESCRIPTION
"Chrome" value is impossible here.
Return value of "TagWebDriver.getBrowserName()" contains only lowercase chars because of:
 public static String getBrowserName() {
      return WEBDRIVER_BROWSER_NAME;
 }
private static final String WEBDRIVER_BROWSER_NAME = Props.get("webdriver.browser.name").toLowerCase().equals("ie")
            // Normalize it for ie shorten name (ie)
            ? BrowserType.IE : Props.get("webdriver.browser.name").toLowerCase();