### PR TITLE
Don't initialize driver if test failed

### DIFF
--- a/src/main/java/ru/sbtqa/tag/pagefactory/PageFactory.java
+++ b/src/main/java/ru/sbtqa/tag/pagefactory/PageFactory.java
@@ -187,4 +187,12 @@ public class PageFactory {
     public static void setSharingProcessing(boolean aIsSharingProcessing) {
         isSharingProcessing = aIsSharingProcessing;
     }
+
+    /**
+     * Return true if webDriver or apiumDriver were initialized
+     * @return {java.boolean} 
+     */
+    public static boolean isDriverInitialized(){
+        return TagWebDriver.isDriverInitialized() || TagMobileDriver.isDriverInitialized();
+    }
 }

--- a/src/main/java/ru/sbtqa/tag/pagefactory/drivers/TagMobileDriver.java
+++ b/src/main/java/ru/sbtqa/tag/pagefactory/drivers/TagMobileDriver.java
@@ -104,4 +104,14 @@ public class TagMobileDriver {
     public static void setMobileDriver(AppiumDriver<AndroidElement> aMobileDriver) {
         mobileDriver = aMobileDriver;
     }
+
+    /**
+     * @return was driver initialized or not
+     */
+    public static boolean isDriverInitialized(){
+        if(mobileDriver != null) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/ru/sbtqa/tag/pagefactory/drivers/TagWebDriver.java
+++ b/src/main/java/ru/sbtqa/tag/pagefactory/drivers/TagWebDriver.java
@@ -214,4 +214,14 @@ public class TagWebDriver {
     public static boolean isWebDriverShared() {
         return WEBDRIVER_SHARED;
     }
+
+    /**
+     * @return was driver initialized or not
+     */
+    public static boolean isDriverInitialized(){
+        if(webDriver != null) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/src/main/java/ru/sbtqa/tag/pagefactory/support/OnFailureScheduler.java
+++ b/src/main/java/ru/sbtqa/tag/pagefactory/support/OnFailureScheduler.java
@@ -2,13 +2,17 @@ package ru.sbtqa.tag.pagefactory.support;
 
 import ru.sbtqa.tag.allurehelper.ParamsHelper;
 import ru.sbtqa.tag.allurehelper.Type;
+import ru.sbtqa.tag.pagefactory.PageFactory;
 import ru.yandex.qatools.allure.cucumberjvm.callback.OnFailureCallback;
 
 public class OnFailureScheduler implements OnFailureCallback {
 
     @Override
     public Object call() {
-        ParamsHelper.addAttachment(ScreenShooter.take(), "Screenshot", Type.PNG);
+        if(PageFactory.isDriverInitialized()) {
+            ParamsHelper.addAttachment(ScreenShooter.take(), "Screenshot", Type.PNG);
+        }
+
         return null;
     }
 }


### PR DESCRIPTION
Now if we used page-factory in api test, driver can be initialized without reason