### PR TITLE
added capability selenoid.sessionTimeout

### DIFF
--- a/src/main/java/ru/sbtqa/tag/pagefactory/support/SelenoidCapabilitiesProvider.java
+++ b/src/main/java/ru/sbtqa/tag/pagefactory/support/SelenoidCapabilitiesProvider.java
@@ -27,6 +27,7 @@ public class SelenoidCapabilitiesProvider {
     private static final String SELENOID_HOST_ENTRIES = Props.get("selenoid.hostEntries");
     private static final String SELENOID_APPLICATION_CONTAINERS = Props.get("selenoid.applicationContainers");
     private static final String SELENOID_CONTAINER_LABLES = Props.get("selenoid.containerLables");
+    private static final String SELENOID_SESSION_TIMEOUT = Props.get("selenoid.sessionTimeout");
 
     public static void apply(DesiredCapabilities capabilities) {
 
@@ -102,6 +103,12 @@ public class SelenoidCapabilitiesProvider {
             capabilities.setCapability("labels", SELENOID_CONTAINER_LABLES);
         } else {
             LOG.info("Capability \"labels\" for Selenoid isn't set. Using default capability.");
+        }
+        
+        if (!SELENOID_SESSION_TIMEOUT.isEmpty()) {
+            capabilities.setCapability("sessionTimeout", SELENOID_SESSION_TIMEOUT);
+        } else { 
+            LOG.info("Capability 'sessionTimeout' for Selenoid isn't set. Using default capability.");
         }
 
         if (TagWebDriver.getBrowserName().equalsIgnoreCase(BrowserType.OPERA)) {


### PR DESCRIPTION
as per documentation: https://aerokube.com/moon/latest/#_custom_session_timeout_sessiontimeout

Sometimes you may want to change idle timeout for selected browser session. To achieve this - pass the following capability:
sessionTimeout: 1m30s
Timeout is always specified in Golang duration format, e.g. 30s or 2m or 1h and so on.

Such capability is required because different timeouts are required for different projects - somewhere 1min is enough, somewhere 30min is too small (I had such strange experience)
